### PR TITLE
Fix Claude Code Integration Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ claude mcp add bookmark-manager -- docker run \
     --rm \
     --interactive \
     --volume ~/.data:/app/.data \
-    docker pull mindriftfall2infinitepiio/bookmark-manager-mcp:latest
+    mindriftfall2infinitepiio/bookmark-manager-mcp:latest
 ```
 
 ## 🔧 VS Code Integration


### PR DESCRIPTION
There was an extra `docker pull` in the docs that caused the integration to fail.